### PR TITLE
Add bid_at time to auction bids

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -218,6 +218,7 @@ ActiveRecordDoctor.configure do
       "Account::User.encrypted_password",
       "Account::User.failed_attempts",
       "Account::User.sign_in_count",
+      "Auctions::Bid.bid_at", # default now() in db
       "Horses::Horse.foals_count",
       "Horses::Horse.unborn_foals_count",
       "Horses::Stallion.foals_count",

--- a/app/models/auctions/bid.rb
+++ b/app/models/auctions/bid.rb
@@ -14,11 +14,11 @@ module Auctions
     validates :maximum_bid, numericality: { greater_than_or_equal_to: :current_bid }, allow_nil: true
     validates :notify_if_outbid, :current_high_bid, inclusion: { in: [true, false] }
 
-    scope :winning, -> { order(maximum_bid: :desc, current_bid: :desc, updated_at: :desc) }
+    scope :winning, -> { order(maximum_bid: :desc, current_bid: :desc, bid_at: :desc) }
     scope :with_bid_matching, ->(amount) { where("GREATEST(current_bid, CAST(maximum_bid AS integer)) >= ?", amount) }
     scope :current_high_bid, -> { where(current_high_bid: true) }
-    scope :sale_time_met, -> { joins(:auction).where("#{table_name}.updated_at <= CURRENT_TIMESTAMP - (auctions.hours_until_sold * INTERVAL '1 hour')") }
-    scope :sale_time_not_met, -> { joins(:auction).where("#{table_name}.updated_at > CURRENT_TIMESTAMP - (auctions.hours_until_sold * INTERVAL '1 hour')") }
+    scope :sale_time_met, -> { joins(:auction).where("#{table_name}.bid_at <= CURRENT_TIMESTAMP - (auctions.hours_until_sold * INTERVAL '1 hour')") }
+    scope :sale_time_not_met, -> { joins(:auction).where("#{table_name}.bid_at > CURRENT_TIMESTAMP - (auctions.hours_until_sold * INTERVAL '1 hour')") }
   end
 end
 
@@ -28,6 +28,7 @@ end
 # Database name: primary
 #
 #  id               :bigint           not null, primary key
+#  bid_at           :datetime         not null, indexed
 #  comment          :text
 #  current_bid      :integer          default(0), not null
 #  current_high_bid :boolean          default(FALSE), not null, indexed
@@ -42,6 +43,7 @@ end
 # Indexes
 #
 #  index_auction_bids_on_auction_id        (auction_id)
+#  index_auction_bids_on_bid_at            (bid_at)
 #  index_auction_bids_on_bidder_id         (bidder_id)
 #  index_auction_bids_on_current_high_bid  (current_high_bid)
 #  index_auction_bids_on_horse_id          (horse_id) UNIQUE WHERE (current_high_bid = true)

--- a/app/services/auctions/bid_deleter.rb
+++ b/app/services/auctions/bid_deleter.rb
@@ -9,7 +9,7 @@ module Auctions
 
         if Auctions::Bid.winning.exists?(horse:)
           previous_bid = Auctions::Bid.winning.find_by!(horse:)
-          previous_bid.update(updated_at: Time.current, current_high_bid: true)
+          previous_bid.update(bid_at: Time.current, current_high_bid: true)
         end
       end
       Result.new(deleted: true, bids:, error: nil)

--- a/app/services/auctions/horse_seller.rb
+++ b/app/services/auctions/horse_seller.rb
@@ -21,7 +21,7 @@ module Auctions
         return result
       end
 
-      if DateTime.current < bid.updated_at + auction.hours_until_sold.hours && DateTime.current < auction.end_time
+      if DateTime.current < bid.bid_at + auction.hours_until_sold.hours && DateTime.current < auction.end_time
         result.error = error("bid_timeout_not_met")
         return result
       end
@@ -66,6 +66,7 @@ module Auctions
       horse_max = auction.horse_purchase_cap_per_stable.to_i
       if horse_max.positive?
         if horses_bought(buyer.id) >= horse_max
+          Auctions::BidDeleter.new.delete_bids(bids: [bid])
           result.error = error("bought_max_horses")
           return result
         end
@@ -74,6 +75,7 @@ module Auctions
       money_max = auction.spending_cap_per_stable.to_i
       if money_max.positive?
         if money_spent(buyer.id) + bid.current_bid > money_max
+          Auctions::BidDeleter.new.delete_bids(bids: [bid])
           result.error = error("spent_max_money")
           return result
         end

--- a/db/data/20251118125311_set_bid_at_for_existing_bids.rb
+++ b/db/data/20251118125311_set_bid_at_for_existing_bids.rb
@@ -1,0 +1,12 @@
+class SetBidAtForExistingBids < ActiveRecord::Migration[8.1]
+  def up
+    Auctions::Bid.where("bid_at > updated_at").find_each do |bid|
+      bid.update(bid_at: bid.updated_at)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end
+

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2025_11_17_094303)
+DataMigrate::Data.define(version: 2025_11_18_125311)

--- a/db/migrate/20251118125017_add_bid_time_to_auction_bids.rb
+++ b/db/migrate/20251118125017_add_bid_time_to_auction_bids.rb
@@ -1,0 +1,11 @@
+class AddBidTimeToAuctionBids < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_column :auction_bids, :bid_at, :datetime, null: false, default: -> { "now()" }
+    end
+    add_index :auction_bids, :bid_at, algorithm: :concurrently
+  end
+end
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -538,7 +538,8 @@ CREATE TABLE public.auction_bids (
     maximum_bid integer,
     created_at timestamp(6) with time zone NOT NULL,
     updated_at timestamp(6) with time zone NOT NULL,
-    current_high_bid boolean DEFAULT false NOT NULL
+    current_high_bid boolean DEFAULT false NOT NULL,
+    bid_at timestamp(6) with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -3265,6 +3266,13 @@ CREATE INDEX index_auction_bids_on_auction_id ON public.auction_bids USING btree
 
 
 --
+-- Name: index_auction_bids_on_bid_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_auction_bids_on_bid_at ON public.auction_bids USING btree (bid_at);
+
+
+--
 -- Name: index_auction_bids_on_bidder_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5038,6 +5046,7 @@ ALTER TABLE ONLY public.horses
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251118125017'),
 ('20251118103702'),
 ('20251115124230'),
 ('20251114085550'),

--- a/spec/factories/auctions/bids.rb
+++ b/spec/factories/auctions/bids.rb
@@ -21,6 +21,7 @@ end
 # Database name: primary
 #
 #  id               :bigint           not null, primary key
+#  bid_at           :datetime         not null, indexed
 #  comment          :text
 #  current_bid      :integer          default(0), not null
 #  current_high_bid :boolean          default(FALSE), not null, indexed
@@ -35,6 +36,7 @@ end
 # Indexes
 #
 #  index_auction_bids_on_auction_id        (auction_id)
+#  index_auction_bids_on_bid_at            (bid_at)
 #  index_auction_bids_on_bidder_id         (bidder_id)
 #  index_auction_bids_on_current_high_bid  (current_high_bid)
 #  index_auction_bids_on_horse_id          (horse_id) UNIQUE WHERE (current_high_bid = true)

--- a/spec/jobs/auctions/process_sales_job_spec.rb
+++ b/spec/jobs/auctions/process_sales_job_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Auctions::ProcessSalesJob, :perform_enqueued_jobs do
                           bidder_id: bidder.id,
                           current_bid: 10_000,
                           current_high_bid: true,
-                          updated_at: DateTime.current - auction.hours_until_sold.hours - 1.second })
+                          bid_at: DateTime.current - auction.hours_until_sold.hours - 1.second })
 
     @bid = Auctions::Bid.find(result.rows.flatten.first)
   end
@@ -47,7 +47,7 @@ RSpec.describe Auctions::ProcessSalesJob, :perform_enqueued_jobs do
                           bidder_id: bidder.id,
                           current_bid: 10_000,
                           current_high_bid: true,
-                          updated_at: DateTime.current - auction.hours_until_sold.hours - 1.second })
+                          bid_at: DateTime.current - auction.hours_until_sold.hours - 1.second })
 
     @bid2 = Auctions::Bid.find(result.rows.flatten.first)
   end

--- a/spec/services/auctions/bid_deleter_spec.rb
+++ b/spec/services/auctions/bid_deleter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Auctions::BidDeleter do
     it "updates data of most recent non-deleted bid" do
       freeze_time
       described_class.new.delete_bids(bids: [bid])
-      expect(previous_bid.reload.updated_at).to eq Time.current
+      expect(previous_bid.reload.bid_at).to eq Time.current
       expect(previous_bid.current_high_bid).to be true
     end
 


### PR DESCRIPTION
Updated_at is too fragile since a ton of things can touch it, so store bid_at time instead. Default in the database to "now()", but can be overridden (like when deleting bids).